### PR TITLE
removed rails_12factor gem and added ruby version to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,12 +24,10 @@ group :development, :test do
   gem 'valid_attribute'
 end
 
-group :production do
-  gem 'rails_12factor'
-end
-
 group :test do
   gem 'coveralls', require: false
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+ruby '2.2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,11 +130,6 @@ GEM
       nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.2)
       actionpack (= 5.0.2)
       activesupport (= 5.0.2)
@@ -229,7 +224,6 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.0)
-  rails_12factor
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   shoulda
@@ -238,6 +232,9 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   valid_attribute
+
+RUBY VERSION
+   ruby 2.2.5p319
 
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
removed rails_12factor gem because it's no longer needed for heroku
added ruby version 2.2.5 to gemfile